### PR TITLE
更新百度百科获取方式

### DIFF
--- a/baiduspider/parser/__init__.py
+++ b/baiduspider/parser/__init__.py
@@ -74,7 +74,10 @@ class Parser(BaseSpider):
                     related.append(self._format(_.text))
         # 预处理百科
         if "baike" not in exclude:
-            baike = soup.find("div", class_="c-container", tpl="bk_polysemy")
+            #先筛选tpl="sg_kg_entity_san"的百科，如果没有再筛选tpl="bk_polysemy"的百科
+            baike = soup.find("div", class_="c-container", tpl="sg_kg_entity_san")
+            if baike is None:
+                baike = soup.find("div", class_="c-container", tpl="bk_polysemy")
             baike = self.webSubParser.parse_baike_block(baike)
         # 预处理贴吧
         if "tieba" not in exclude:
@@ -150,7 +153,7 @@ class Parser(BaseSpider):
         # 预处理源码
         soup = BeautifulSoup(content, "html.parser")
         results = []
-        for res in soup.findAll("div", class_="result-op"):
+        for res in soup.findAll("div", class_="c-container"):
             try:
                 if res["srcid"] in ["1599"]:
                     results.append(res)

--- a/baiduspider/parser/subparser.py
+++ b/baiduspider/parser/subparser.py
@@ -108,60 +108,65 @@ class WebSubParser(BaseSpider):
         Returns:
             Dict: 解析后自动生成的Python结果字典对象
         """
-        if baike:
-            b_title = self._format(baike.find("h3").text)
-            b_url = baike.find("a")["href"]
-            #如果百科的tpl==bk_polysemy
-            if baike["tpl"] == "bk_polysemy":
-                b_des = self._format(
-                    baike.find("div", class_="c-span-last")
-                    .find("div", class_="c-font-normal")
-                    .text
-                )
+        if not baike:
+            return {}
+
+        b_title = self._format(baike.find("h3").text)
+        b_url = baike.find("a")["href"]
+        
+        # 如果百科的tpl==bk_polysemy
+        if baike["tpl"] == "bk_polysemy":
+            b_des = self._format(
+                baike.find("div", class_="c-span-last")
+                .find("div", class_="c-font-normal")
+                .text
+            )
+            try:
+                b_cover = baike.find("div", class_="c-span3").find("img")["src"]
+                b_cover_type = "image"
+            except (TypeError, AttributeError):
                 try:
-                    b_cover = baike.find("div", class_="c-span3").find("img")["src"]
-                    b_cover_type = "image"
-                except (TypeError, AttributeError):
-                    try:
-                        b_cover = (
-                            baike.find("div", class_="op-bk-polysemy-imgWrap")
-                            .find("div", class_="c-img")["style"]
-                            .split("url", 1)[-1]
-                            .split(")", 1)[0]
-                            .strip("(")
-                        )
-                        b_cover_type = "video"
-                    except (TypeError):
-                        b_cover = None
-                        b_cover_type = None
-            #如果百科的tpl==sg_kg_entity_san
-            elif baike["tpl"] == "sg_kg_entity_san":
-                b_des = self._format(
-                    baike.find("div", class_="description_1rAFH")
-                    .find("p", class_="cu-font-normal")
-                    .text
-                )
-                try:
-                    b_cover = baike.find("div", class_="_image_1gdgv_1").find("img")["src"]
-                    #如果能找到class==cos-icon的i标签，则说明是视频，否则是图片
-                    b_cover_type = "video" if baike.find("i", class_="cos-icon") else "image"
-                except (TypeError, AttributeError):
+                    b_cover = (
+                        baike.find("div", class_="op-bk-polysemy-imgWrap")
+                        .find("div", class_="c-img")["style"]
+                        .split("url", 1)[-1]
+                        .split(")", 1)[0]
+                        .strip("(")
+                    )
+                    b_cover_type = "video"
+                except (TypeError):
                     b_cover = None
                     b_cover_type = None
-
-            else:
-                b_des = None
+                    
+        # 如果百科的tpl==sg_kg_entity_san
+        elif baike["tpl"] == "sg_kg_entity_san":
+            b_des = self._format(
+                baike.find("div", class_="description_1rAFH")
+                .find("p", class_="cu-font-normal")
+                .text
+            )
+            try:
+                b_cover = baike.find("div", class_="_image_1gdgv_1").find("img")["src"]
+                # 如果能找到class==cos-icon的i标签，则说明是视频，否则是图片
+                b_cover_type = "video" if baike.find("i", class_="cos-icon") else "image"
+            except (TypeError, AttributeError):
                 b_cover = None
                 b_cover_type = None
 
-            baike = {
-                "title": b_title,
-                "url": b_url,
-                "des": b_des,
-                "cover": b_cover,
-                "cover-type": b_cover_type,
-            }
+        else:
+            b_des = None
+            b_cover = None
+            b_cover_type = None
+            
+        baike = {
+            "title": b_title,
+            "url": b_url,
+            "des": b_des,
+            "cover": b_cover,
+            "cover-type": b_cover_type,
+        }
         return baike
+
 
     @handle_err
     def parse_tieba_block(self, tieba: BeautifulSoup) -> Dict:

--- a/baiduspider/parser/subparser.py
+++ b/baiduspider/parser/subparser.py
@@ -108,39 +108,59 @@ class WebSubParser(BaseSpider):
         Returns:
             Dict: 解析后自动生成的Python结果字典对象
         """
-        if not baike:
-            return {}
-
-        b_title = self._format(baike.find("h3").text)
-        b_url = baike.find("a")["href"]
-        b_des = self._format(
-            baike.find("div", class_="c-span-last")
-            .find("div", class_="c-font-normal")
-            .text
-        )
-        try:
-            b_cover = baike.find("div", class_="c-span3").find("img")["src"]
-            b_cover_type = "image"
-        except (TypeError, AttributeError):
-            try:
-                b_cover = (
-                    baike.find("div", class_="op-bk-polysemy-imgWrap")
-                    .find("div", class_="c-img")["style"]
-                    .split("url", 1)[-1]
-                    .split(")", 1)[0]
-                    .strip("(")
+        if baike:
+            b_title = self._format(baike.find("h3").text)
+            b_url = baike.find("a")["href"]
+            #如果百科的tpl==bk_polysemy
+            if baike["tpl"] == "bk_polysemy":
+                b_des = self._format(
+                    baike.find("div", class_="c-span-last")
+                    .find("div", class_="c-font-normal")
+                    .text
                 )
-                b_cover_type = "video"
-            except TypeError:
+                try:
+                    b_cover = baike.find("div", class_="c-span3").find("img")["src"]
+                    b_cover_type = "image"
+                except (TypeError, AttributeError):
+                    try:
+                        b_cover = (
+                            baike.find("div", class_="op-bk-polysemy-imgWrap")
+                            .find("div", class_="c-img")["style"]
+                            .split("url", 1)[-1]
+                            .split(")", 1)[0]
+                            .strip("(")
+                        )
+                        b_cover_type = "video"
+                    except (TypeError):
+                        b_cover = None
+                        b_cover_type = None
+            #如果百科的tpl==sg_kg_entity_san
+            elif baike["tpl"] == "sg_kg_entity_san":
+                b_des = self._format(
+                    baike.find("div", class_="description_1rAFH")
+                    .find("p", class_="cu-font-normal")
+                    .text
+                )
+                try:
+                    b_cover = baike.find("div", class_="_image_1gdgv_1").find("img")["src"]
+                    #如果能找到class==cos-icon的i标签，则说明是视频，否则是图片
+                    b_cover_type = "video" if baike.find("i", class_="cos-icon") else "image"
+                except (TypeError, AttributeError):
+                    b_cover = None
+                    b_cover_type = None
+
+            else:
+                b_des = None
                 b_cover = None
                 b_cover_type = None
-        baike = {
-            "title": b_title,
-            "url": b_url,
-            "des": b_des,
-            "cover": b_cover,
-            "cover-type": b_cover_type,
-        }
+
+            baike = {
+                "title": b_title,
+                "url": b_url,
+                "des": b_des,
+                "cover": b_cover,
+                "cover-type": b_cover_type,
+            }
         return baike
 
     @handle_err


### PR DESCRIPTION

**你在该请求中做了些什么？**
更新百度百科获取方式。
现在百度搜索中位于优先位置的百度百科通常是 tpl="sg_kg_entity_san"的，这种情况下的百度百科搜索结果往往优于tpl="bk_polysemy"。
所以我将tpl="sg_kg_entity_san"作为筛选百度百科的优先条件，tpl="bk_polysemy"次之。
此更新后，百度百科的搜索结果将更符合用户需要。